### PR TITLE
fix: Use stable CDN for AR.js library

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" href="data:,">
     <!-- A-Frame and AR.js scripts -->
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
-    <script src="https://raw.githack.com/AR-js-org/AR.js/master/aframe/build/aframe-ar-nft.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@ar-js-org/ar.js@3/aframe/build/aframe-ar-nft.js"></script>
     <link rel="stylesheet" href="style.css">
   </head>
   <body style="margin: 0px; overflow: hidden;">


### PR DESCRIPTION
I replaced the unstable `raw.githack.com` URL, which points to the AR.js master branch, with a version-locked CDN link from jsDelivr.

This prevents unexpected breakages from upstream changes in the library and improves the overall stability of your application.